### PR TITLE
Doku: CM4 Carrier index.md vollständig überarbeitet

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -124,15 +124,15 @@ Standard UART-Parameter des CM4-Bootloaders + Raspberry Pi OS: **115200 8N1** (s
 
 ## rpiboot-Workflow (CM4 flashen)
 
-Der CM4-Carrier hat **keinen eigenen rpiboot-Jumper**. Stattdessen sind die zwei dafür nötigen Pins (`nRPIBOOT` und `USB_OTG_ID`) auf den Bus-Stecker geführt (`J101 b9` und `J101 b8`). Auf dem [DeviceTester](../HW-Module-DeviceTester/) werden sie über den 4-Pin Flash-Header `J202` **manuell** per Jumper auf GND gelegt:
+Der CM4-Carrier hat **keinen eigenen rpiboot-Jumper**. Stattdessen sind die zwei dafür nötigen Pins (`nRPIBOOT` und `USB_OTG_ID`) auf den Bus-Stecker geführt (`J101 b9` und `J101 b8`). Auf dem [DeviceTester](../HW-Module-DeviceTester/) werden sie über den 4-Pin Flash-Header `J202` **manuell** per Jumper gesetzt — beide Pins nebeneinander mit jeweils GND bzw. +5V als Nachbar:
 
-- **`nRPIBOOT` → GND** versetzt den CM4 nach Power-Up in den USB-Boot-Modus statt vom eMMC/SD zu booten.
-- **`USB_OTG_ID` → GND** schaltet die USB-Schnittstelle in den Device-Mode (CM4 als USB-Gerät, PC als Host).
+- **`nRPIBOOT` → GND** (Pin 2 ↔ Pin 1): versetzt den CM4 nach Power-Up in den USB-Boot-Modus statt vom eMMC zu booten.
+- **`USB_OTG_ID` → +5V** (Pin 3 ↔ Pin 4): schaltet die USB-Schnittstelle in den Device-Mode (CM4 als USB-Gerät, PC als Host).
 
 Ablauf:
 
 1. CM4 in den Carrier einsetzen, Carrier in den DeviceTester (Bus-Stecker `J101` ↔ DeviceTester `J203`) einsetzen.
-2. Auf dem DeviceTester am 4-Pin-Header `J202` **beide** Jumper setzen — Pin 1↔2 (nRPIBOOT auf GND) und Pin 1↔3 (USB_OTG_ID auf GND).
+2. Auf dem DeviceTester am 4-Pin-Header `J202` **beide** Jumper setzen — Pin 1↔2 (nRPIBOOT auf GND) und Pin 3↔4 (USB_OTG_ID auf +5V).
 3. DeviceTester per USB-C mit dem PC verbinden (`J201`).
 4. `rpiboot` auf dem PC starten — der CM4 erscheint als USB-Mass-Storage-Device (eMMC-Variante) bzw. erlaubt einen direkten Image-Schreib-Vorgang.
 5. Nach Abschluss: Jumper am DeviceTester wieder abziehen, sonst bootet der Carrier beim nächsten Power-Up wieder in den rpiboot-Mode statt regulär.

--- a/doc/index.md
+++ b/doc/index.md
@@ -24,7 +24,7 @@ Trägerplatine für das Raspberry Pi Compute Module 4 (CM4). Das CM4 steckt übe
 - **USB-Host** — über den Bus-Stecker zum [BusBoard](../HW-Module-BusBoard/) → FE1.1s-Hub → 4 Modul-Slots.
 - **I²C** — über den Bus-Stecker zum [PowerBoard](../HW-Module-PowerBoard/) (Lesen der INA226-Messwerte).
 - **UART-Debug** — 3-Pin-Header `J102` direkt für seriellen Konsolen-Zugriff (siehe „Debug-Header" unten).
-- **rpiboot** — Flash-Pin (`nRPIBOOT`) ist auf den Bus-Stecker geführt; wird durch das [DeviceTester-Modul](../HW-Module-DeviceTester/) auf GND gezogen, sobald der Carrier dort eingesteckt ist.
+- **rpiboot** — Flash-Pin (`nRPIBOOT`) ist auf den Bus-Stecker geführt; wird im [DeviceTester](../HW-Module-DeviceTester/) per **manuell gesetztem Jumper** am 4-Pin Flash-Header (`J202`) auf GND gezogen, um den CM4 in den Flash-Modus zu versetzen.
 
 ## Block-Diagramm
 
@@ -124,13 +124,20 @@ Standard UART-Parameter des CM4-Bootloaders + Raspberry Pi OS: **115200 8N1** (s
 
 ## rpiboot-Workflow (CM4 flashen)
 
-Der CM4-Carrier hat **keinen eigenen rpiboot-Jumper**. Stattdessen ist der `nRPIBOOT`-Pin auf den Bus-Stecker `J101 b9` geführt und wird durch das [DeviceTester-Modul](../HW-Module-DeviceTester/) auf GND gezogen, wenn man den Carrier dort einsteckt.
+Der CM4-Carrier hat **keinen eigenen rpiboot-Jumper**. Stattdessen sind die zwei dafür nötigen Pins (`nRPIBOOT` und `USB_OTG_ID`) auf den Bus-Stecker geführt (`J101 b9` und `J101 b8`). Auf dem [DeviceTester](../HW-Module-DeviceTester/) werden sie über den 4-Pin Flash-Header `J202` **manuell** per Jumper auf GND gelegt:
+
+- **`nRPIBOOT` → GND** versetzt den CM4 nach Power-Up in den USB-Boot-Modus statt vom eMMC/SD zu booten.
+- **`USB_OTG_ID` → GND** schaltet die USB-Schnittstelle in den Device-Mode (CM4 als USB-Gerät, PC als Host).
 
 Ablauf:
 
-1. Carrier in den DeviceTester einsetzen (entsprechenden Jumper am DeviceTester setzen — siehe DeviceTester-Doku).
-2. DeviceTester per USB-C mit dem PC verbinden.
-3. `rpiboot` auf dem PC starten — der CM4 erscheint als USB-Mass-Storage-Device (für eMMC) bzw. wartet auf Image-Schreib-Kommando.
+1. CM4 in den Carrier einsetzen, Carrier in den DeviceTester (Bus-Stecker `J101` ↔ DeviceTester `J203`) einsetzen.
+2. Auf dem DeviceTester am 4-Pin-Header `J202` **beide** Jumper setzen — Pin 1↔2 (nRPIBOOT auf GND) und Pin 1↔3 (USB_OTG_ID auf GND).
+3. DeviceTester per USB-C mit dem PC verbinden (`J201`).
+4. `rpiboot` auf dem PC starten — der CM4 erscheint als USB-Mass-Storage-Device (eMMC-Variante) bzw. erlaubt einen direkten Image-Schreib-Vorgang.
+5. Nach Abschluss: Jumper am DeviceTester wieder abziehen, sonst bootet der Carrier beim nächsten Power-Up wieder in den rpiboot-Mode statt regulär.
+
+⚠️ **Funktioniert nur mit der eMMC-Variante** des CM4 — eMMC-less / lite-CM4s booten ohnehin von SD und brauchen keinen Flash-Schritt; einfach SD-Karte mit dem Image bestücken.
 
 ## Bringup
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -2,6 +2,7 @@
 title: CM4 Carrier
 nav_order: 4
 parent: Hardware
+description: Trägerplatine für das Raspberry-Pi-CM4 mit Ethernet, microSD, UART-Debug und Anbindung an Bus + Power über den 20-Pin-Stecker.
 ---
 
 # CM4 Carrier PCB
@@ -14,24 +15,138 @@ parent: Hardware
   </tr>
 </table>
 
-Das `CM4` Modul beherbergt das Gehirn der Remote Station: ein Computer Module 4 (CM4) von Raspberry Pi.
-Das CM4 ist eine einfache Platine welche CPU, Speicher, Wifi und andere Komponenten direkt aufgelötet hat. Somit können über die zwei 100pin Stecker alle Schnittstellen direkt angesprochen werden.
+## Übersicht
 
-**Verwendete Schnittstellen:**
+Trägerplatine für das Raspberry Pi Compute Module 4 (CM4). Das CM4 steckt über zwei 100-Pin Hirose-DF40C-Connectoren auf dem Carrier und bringt CPU, RAM, optional eMMC sowie Schnittstellen (Ethernet, USB, I²C, UART, GPIO) mit. Der Carrier macht die genutzten Schnittstellen physisch zugänglich:
 
-| CM4 Schnittstelle | Anwendung                                                                          |
-| ----------------- | ---------------------------------------------------------------------------------- |
-| I<sup>2</sup>C    | Messen der Versorgungsspannungen und Ströme                                        |
-| Ethernet          | für die Verbindung zum Internet oder andere Netzwerke (Lan, externes Modem, etc.)  |
-| SD-Card           | für die Software (im Produktiven Betrieb soll das interne eMMC verwendet werden)   |
-| USB               | zum aufspielen eines neuen Images in den eMMC oder zum ansprechen der Bus-Devices  |
+- **Ethernet** (Gigabit) — RJ45 mit integrierten Magnetics (HR911130A) für LAN-Anbindung.
+- **microSD** — Boot-Medium für *eMMC-less* CM4-Varianten („lite") sowie Test-/Entwicklungs-Builds.
+- **USB-Host** — über den Bus-Stecker zum [BusBoard](../HW-Module-BusBoard/) → FE1.1s-Hub → 4 Modul-Slots.
+- **I²C** — über den Bus-Stecker zum [PowerBoard](../HW-Module-PowerBoard/) (Lesen der INA226-Messwerte).
+- **UART-Debug** — 3-Pin-Header `J102` direkt für seriellen Konsolen-Zugriff (siehe „Debug-Header" unten).
+- **rpiboot** — Flash-Pin (`nRPIBOOT`) ist auf den Bus-Stecker geführt; wird durch das [DeviceTester-Modul](../HW-Module-DeviceTester/) auf GND gezogen, sobald der Carrier dort eingesteckt ist.
 
-Der benötigter Strom für das CM4 ist immer stark Abhängig welche Schnittstellen aktiv sind. Bei einem Raspberry Pi 4 kann dies bis zu 3A betragen. Nachdem jedoch kein HDMI vorgesehen ist wird sich der benötigter Strom auf unter 1A beschränken.
+## Block-Diagramm
 
-| Spannung | benötigter Strom |
-| -------- | ---------------- |
-|      +5V |          max. 1A |
-|     +12V |                - |
+```mermaid
+flowchart LR
+    CM4["CM4<br/>(2× DF40C-100DS)"]
+    CM4 <-->|"RGMII"| RJ45["HR911130A<br/>RJ45 + Magnetics"]
+    CM4 <-->|"SD bus"| SD["microSD<br/>(TF-01A)"]
+    CM4 -->|"SD_PWR_ON"| LS["RT9742<br/>Load-Switch"]
+    LS -->|"+3V3 gated"| SD
+    CM4 -->|"LED_nPWR"| Buf["SN74LV1T34<br/>Buffer"]
+    Buf --> LEDp["Power-LED D202"]
+    CM4 -->|"LED_nACTIVITY"| LEDa["Activity-LED D201"]
+
+    CM4 -->|"USB D±, USB_ID, I²C, nRPIBOOT"| ESD["TPD4EUSB30 ×2<br/>(USB ESD)"]
+    ESD --> Bus["Bus-Stecker J101"]
+
+    UART(["UART RXD0 / TXD0"]) <--> CM4
+    UART --> J102["J102 Debug-Header"]
+
+    Bus -.->|"USB Host"| BB["BusBoard → FE1.1s → 4 Slots"]
+    Bus -.->|"I²C (SDA/SCL)"| PB["PowerBoard (INA226)"]
+    Bus -.->|"nRPIBOOT"| DT["DeviceTester (zum Flashen)"]
+```
+
+## CM4-Varianten-Kompatibilität
+
+| Variante | Unterstützt | Zweck |
+| -------- | :---------: | ----- |
+| eMMC (alle RAM-Größen) | ✅ | **Produktiv-Betrieb** — Boot vom internen eMMC |
+| eMMC-less / „lite" (alle RAM-Größen) | ✅ | **Test/Entwicklung** — Boot von microSD |
+| Wifi-Variante | ❌ | nicht vorgesehen — keine Antennen-Anbindung auf dem Carrier |
+
+Der CM4 ermittelt das Boot-Medium automatisch anhand seiner Hardware: eMMC-Varianten booten vom eMMC, lite-Varianten von microSD. **Kein Mix-and-Match** möglich.
+
+## Steckverbinder
+
+| Bezeichner | Typ | Funktion |
+| ---------- | --- | -------- |
+| **J101** | 20-Pin (Hirose PCN10-20P-2.54DSA) | Bus-Anschluss zum [BusBoard](../HW-Module-BusBoard/). Versorgung (+5V/+12V/GND), USB-Host, I²C, USB_ID, nRPIBOOT. |
+| **J102** | 3-Pin Header (2.54 mm Raster) | UART-Debug. Pin 1 = `GND`, Pin 2 = `RXD0`, Pin 3 = `TXD0`. *Pin-1-Lage im Silkscreen noch nicht markiert — siehe [Issue #3](https://github.com/OE5XRX/HW-Module-CM4Carrier/issues/3).* |
+| **J201, J202** | 2× DF40C-100DS-0.4V_51_ | CM4-Footprint (Board-to-Board, 0.4 mm Raster, 100 Pin pro Stecker). |
+| **J301** | HR911130A RJ45 | Gigabit Ethernet inkl. Magnetics + Link/Activity-LEDs. |
+
+### Bus-Stecker `J101` — Lokale Pin-Numerierung
+
+Achtung: Die Pin-Numerierung auf dem Carrier ist **gespiegelt** ggü. der Bus-Seite (BusBoard's `J201` Pin a1 mated mit CM4Carrier's `J101` Pin a10 etc.). Physikalisch passt's; die Signale stimmen überein. Für die *kanonische* Bus-Pinbelegung siehe [BusBoard](../HW-Module-BusBoard/#pin-belegung-20-pin-identisch-auf-allen-konnektoren).
+
+Carrier-eigene Sicht auf `J101`:
+
+| Pin | Net | Pin | Net |
+|----:|-----|----:|-----|
+| a1  | +12V | b1  | +12V |
+| a2  | +12V | b2  | +12V |
+| a3  | GND  | b3  | GND  |
+| a4  | +5V  | b4  | +5V  |
+| a5  | +5V  | b5  | +5V  |
+| a6  | USB D+ | b6 | USB D− |
+| a7  | NC   | b7  | NC   |
+| a8  | I²C SDA | b8 | USB_ID |
+| a9  | I²C SCL | b9 | nRPIBOOT |
+| a10 | GND  | b10 | GND  |
+
+## Auf dem Carrier verbaute Komponenten
+
+| Bauteil | Funktion |
+| ------- | -------- |
+| **RT9742GGJ5** (U401) | Load-Switch / Strombegrenzer. Steuert die Versorgung der microSD-Karte (Eingang `SD_PWR_ON` vom CM4 → Ausgang gefilterte +3V3 zur SD-Karte). Erlaubt SD-Power-Cycle vom CM4. |
+| **SN74LV1T34DBV** (U201) | Single-Buffer / Level-Shifter (3.3 V). Treibt die Power-LED aus dem CM4-Signal `LED_nPWR` heraus — entkoppelt von schwachen CM4-Boot-Pin-Treibstärken. |
+| **2× TPD4EUSB30** (U301, U302) | USB-ESD-Schutz (TI 4-Kanal TVS). Schützt die USB-Datenleitungen vor Spitzen am Bus-Stecker. |
+| **D201 (Activity-LED)** | Direkt vom CM4-Pin `LED_nACTIVITY` via Vorwiderstand (R201). Blinkt bei eMMC- oder SD-I/O. |
+| **D202 (Power-LED)** | Über den SN74LV1T34-Buffer vom CM4-Pin `LED_nPWR`. Leuchtet sobald der CM4 läuft. |
+
+Hinweis: Der Carrier hat **keine eigenen I²C-Slaves**. Der I²C-Bus wird unverändert zwischen CM4 und BusBoard durchgereicht; die einzigen I²C-Devices in der Remote Station sind die zwei INA226 auf dem [PowerBoard](../HW-Module-PowerBoard/) (`0x40` und `0x41`).
+
+## Versorgung
+
+| Rail | Quelle | Verbrauch |
+| ---- | ------ | --------- |
+| +5V  | Bus-Stecker (vom [PowerBoard](../HW-Module-PowerBoard/)) | < 1 A typ. (kein HDMI angeschlossen) |
+| +3V3 | CM4-intern (am DF40C verfügbar) | für lokale Logik: SN74LV1T34, RT9742, RJ45-LEDs |
+| +12V | Bus durchgeschleift | nicht direkt vom Carrier genutzt |
+
+## Debug-Header (J102)
+
+3-Pin-Stiftleiste, 2.54 mm Raster:
+
+| Pin | Signal | Beschreibung |
+|----:|--------|--------------|
+| 1 | `GND` | Masse-Referenz |
+| 2 | `RXD0` | UART RX vom CM4 (PC sendet hier hinein) |
+| 3 | `TXD0` | UART TX vom CM4 (PC empfängt hier) |
+
+**Pin-1-Lage im Silkscreen ist auf der aktuellen Revision NICHT markiert** ([Issue #3](https://github.com/OE5XRX/HW-Module-CM4Carrier/issues/3)) — Schaltplan zu Rate ziehen oder die Adapter-Pinbelegung kurz mit einem Multimeter gegen GND verifizieren bevor angeschlossen wird.
+
+Standard UART-Parameter des CM4-Bootloaders + Raspberry Pi OS: **115200 8N1** (sofern in `config.txt` / `cmdline.txt` nicht überschrieben).
+
+## rpiboot-Workflow (CM4 flashen)
+
+Der CM4-Carrier hat **keinen eigenen rpiboot-Jumper**. Stattdessen ist der `nRPIBOOT`-Pin auf den Bus-Stecker `J101 b9` geführt und wird durch das [DeviceTester-Modul](../HW-Module-DeviceTester/) auf GND gezogen, wenn man den Carrier dort einsteckt.
+
+Ablauf:
+
+1. Carrier in den DeviceTester einsetzen (entsprechenden Jumper am DeviceTester setzen — siehe DeviceTester-Doku).
+2. DeviceTester per USB-C mit dem PC verbinden.
+3. `rpiboot` auf dem PC starten — der CM4 erscheint als USB-Mass-Storage-Device (für eMMC) bzw. wartet auf Image-Schreib-Kommando.
+
+## Bringup
+
+Nach Bestückung und mit eingesetztem CM4:
+
+1. **Optisch:** Power-LED `D202` muss kurz nach Anlegen von +5V leuchten. Wenn nicht: prüfen ob CM4 korrekt sitzt und der eMMC-Variantenwahl entspricht (lite-Variante ohne SD-Karte hat nichts zum Booten).
+2. **Activity-LED:** `D201` blinkt unregelmäßig sobald der CM4 mit dem eMMC/SD redet.
+3. **Ethernet:** RJ45 einstecken — beide LEDs am Stecker (Link gelb, Activity grün) sollten passend zur Netzwerklage aufleuchten.
+4. **UART-Konsole:** USB-TTL-Adapter (3.3 V Level!) an `J102` (GND/RX/TX) anschließen, 115200 8N1 → CM4-Bootloader + Linux-Boot sichtbar.
+5. **I²C-Sanity:** vom CM4 `i2cdetect -y 1` ausführen → die zwei INA226-Adressen `0x40` und `0x41` aus dem PowerBoard müssen ACK geben.
+
+## Verwandte Module
+
+- [BusBoard](../HW-Module-BusBoard/) — nimmt den USB-Host des CM4 entgegen und verteilt ihn als 4-Port-Hub auf die Modulslots.
+- [PowerBoard](../HW-Module-PowerBoard/) — speist +5V/+12V via Bus ein; INA226 werden vom CM4 per I²C ausgelesen.
+- [DeviceTester](../HW-Module-DeviceTester/) — zieht `nRPIBOOT` für rpiboot-Mode auf GND und stellt USB-C zum Flash-PC bereit.
 
 ## Daten
 


### PR DESCRIPTION
## Summary

Vollwertige Überarbeitung der CM4-Carrier-Doku im selben Stil wie PowerBoard #6 / BusBoard #5.

Neue Sektionen:
- Description front-matter
- Übersicht mit Liste der CM4-Schnittstellen
- Mermaid Block-Diagramm (CM4 + SD-Power-Switch + LED-Buffer + USB-ESD + Bus)
- **CM4-Varianten-Kompatibilität** Tabelle (eMMC, eMMC-less, alle RAM-Größen; **non-Wifi only**)
- Steckverbinder-Übersicht (J101 Bus, J102 UART-Debug, J201/J202 DF40C, J301 RJ45)
- Bus-Stecker J101 mit Pinout (Carrier-eigene Nummerierung; Hinweis auf Spiegelung ggü. BusBoard)
- Komponenten-Tabelle (RT9742 SD load-switch, SN74LV1T34 LED-buffer, TPD4EUSB30 ×2 ESD, D201 Activity, D202 Power) — aus Netlist extrahiert
- Versorgung
- **UART-Debug-Header J102** mit Pinbelegung — Pin 1 TBD-Note verlinkt auf [Issue #3](https://github.com/OE5XRX/HW-Module-CM4Carrier/issues/3)
- **rpiboot-Workflow** — Delegation an DeviceTester (nRPIBOOT auf Bus-Pin b9)
- Bringup-Checkliste
- Cross-Links

## Issue created

[#3 — UART-Debug-Header (J102): Pin-1-Lage im Silkscreen markieren](https://github.com/OE5XRX/HW-Module-CM4Carrier/issues/3)

## Test plan

- [x] 8× site.data.project.name, keine stray main- refs
- [ ] kibot-check passes on PR
- [ ] Post-merge debug-docs runs and gh-pages updates (GitHub Pages wurde gerade aktiviert — sollte jetzt erstmals deployen)