### PR TITLE
chore: migrate <<HASH>> placeholder to <<VERSION>>

### DIFF
--- a/CM4Carrier.kicad_pcb
+++ b/CM4Carrier.kicad_pcb
@@ -9,7 +9,7 @@
 	(paper "A4")
 	(title_block
 		(title "CM4")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 		(comment 1 "JLC04161H-7628")
 	)
@@ -14528,7 +14528,7 @@
 			(justify left bottom)
 		)
 	)
-	(gr_text "<<HASH>>"
+	(gr_text "<<VERSION>>"
 		(at 118.114 132.408 0)
 		(layer "F.SilkS")
 		(uuid "2e600c3d-66b0-4552-a461-f5461cbf5635")

--- a/CM4Carrier.kicad_sch
+++ b/CM4Carrier.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "Bus Connector")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/cm4-board.kicad_sch
+++ b/cm4-board.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "CM4 Board")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/ethernet.kicad_sch
+++ b/ethernet.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "Ethernet Port for CM4")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/micro_sd.kicad_sch
+++ b/micro_sd.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "MicroSD Slot for CM4 (just for debugging!)")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols


### PR DESCRIPTION
## Summary

- Mechanisches sed-Replace `<<HASH>>` → `<<VERSION>>` in allen `.kicad_sch` und `.kicad_pcb`-Files.
- Keine elektrische oder Layout-Änderung — nur der Platzhalter-Name im Titelblock-Silkscreen.

## Phase 3 von 7 — Release-Konzept

- **Phase 1**: VERSIONING.md auf OE5XRX.github.io ([PR #3](https://github.com/OE5XRX/OE5XRX.github.io/pull/3))
- **Phase 2**: HW-Module-CI Workflow-Umstellung ([PR #4](https://github.com/OE5XRX/HW-Module-CI/pull/4)) — **muss zuerst gemergt sein**
- **Phase 3**: Diese PR (5 parallel — 1 pro Modul-Repo)

### Merge-Reihenfolge

1. HW-Module-CI#4 mergen
2. Direkt danach diese PR + die 4 Schwestern in den anderen Modul-Repos

Während des Zeitfensters zeigt das Titelblock kurzzeitig literal `<<HASH>>` (CI sucht nach `<<VERSION>>`, findet nichts, kein Substitut). Beim ersten `push:main` nach den Merges ist alles wieder konsistent.

## Test plan

- [ ] KiCad-Check CI grün (ERC + DRC unverändert)
- [ ] Nach Merge: einmal `workflow_dispatch` von „Create Debug Docs" und sichten dass im PDF-Schaltplan das Titelblock z.B. `BETA-<commit>` zeigt
- [ ] Erst danach `v1.0`-Release triggern (Phase 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)